### PR TITLE
ci: use anvil server in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,4 +22,10 @@ jobs:
         uses: borales/actions-yarn@v4
         with:
           cmd: install
-      - run: env ZERO_X_PROXY_API_DOMAIN=${{ secrets.ZERO_X_PROXY_API_DOMAIN }} env ZERO_X_API_KEY=${{ secrets.ZERO_X_API_KEY }} env NETWORK_NAME=Ethereum yarn test-fork
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Run Anvil and fork test
+        uses: BerniWittmann/background-server-action@v1
+        with:
+          command: env ZERO_X_PROXY_API_DOMAIN=${{ secrets.ZERO_X_PROXY_API_DOMAIN }} env ZERO_X_API_KEY=${{ secrets.ZERO_X_API_KEY }} env NETWORK_NAME=Ethereum yarn test-fork
+          start: ./run-anvil Ethereum https://uber.us.proxy.railwayapi.xyz/rpc/alchemy/eth-mainnet --silent

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,6 +26,10 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run Anvil and fork test
         uses: BerniWittmann/background-server-action@v1
+        env:
+          ZERO_X_PROXY_API_DOMAIN: ${{ secrets.ZERO_X_PROXY_API_DOMAIN }}
+          ZERO_X_API_KEY: ${{ secrets.ZERO_X_API_KEY }}
+          NETWORK_NAME: Ethereum
         with:
-          command: env ZERO_X_PROXY_API_DOMAIN=${{ secrets.ZERO_X_PROXY_API_DOMAIN }} env ZERO_X_API_KEY=${{ secrets.ZERO_X_API_KEY }} env NETWORK_NAME=Ethereum yarn test-fork
+          command: r=3;while ! yarn test-fork ; do ((--r))||exit;sleep 1;done
           start: ./run-anvil Ethereum https://uber.us.proxy.railwayapi.xyz/rpc/alchemy/eth-mainnet --silent

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,4 +22,10 @@ jobs:
         uses: borales/actions-yarn@v4
         with:
           cmd: install
-      - run: env ZERO_X_PROXY_API_DOMAIN=${{ secrets.ZERO_X_PROXY_API_DOMAIN }} env ZERO_X_API_KEY=${{ secrets.ZERO_X_API_KEY }} yarn test
+      - name: Yarn test up to 3 times
+        shell: bash
+        env:
+          ZERO_X_PROXY_API_DOMAIN: ${{ secrets.ZERO_X_PROXY_API_DOMAIN }}
+          ZERO_X_API_KEY: ${{ secrets.ZERO_X_API_KEY }}
+        run: # Try yarn test 3 times before failing
+          r=3;while ! yarn test ; do ((--r))||exit;sleep 1;done

--- a/run-anvil
+++ b/run-anvil
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -lt 2 ]; then
     echo "ERROR: Requires 2 parameters: run-anvil <chain-identifier> <fork-url>"
     exit 1;
 fi
@@ -20,7 +20,10 @@ case $1 in
     ;;
 esac
 
+# $3 allows for additional options to be passed to anvil
+
 anvil \
+    $3 \
     --fork-url $2 \
     --port $PORT \
     --chain-id $CHAIN_ID \


### PR DESCRIPTION
Runs anvil as a server, so we can run `yarn test-fork` in the foreground.

The integration test is failing due to an issue that seems real:

```
  4) FORK-run-beefy-vault-recipes
       [FORK] Should run beefy-deposit-recipe:
     Error: Beefy vault is not active for ID: convex-steth.
      at Function.getBeefyVaultForID (src/api/beefy/beefy-api.ts:309:13)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async Context.run (src/recipes/vault/beefy/__tests__/FORK-run-beefy-vault-recipes.test.ts:59:19)
  5) FORK-run-beefy-vault-recipes
       [FORK] Should run beefy-withdraw-recipe:
     Error: Beefy vault is not active for ID: convex-steth.
      at Function.getBeefyVaultForID (src/api/beefy/beefy-api.ts:309:13)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async Context.run (src/recipes/vault/beefy/__tests__/FORK-run-beefy-vault-recipes.test.ts:161:19)
```
