### PR TITLE
Fix integration test expected value

### DIFF
--- a/src/combo-meals/liquidity-vault/__tests__/FORK-run-uni-v2-like-liquidity-beefy-combo-meals.test.ts
+++ b/src/combo-meals/liquidity-vault/__tests__/FORK-run-uni-v2-like-liquidity-beefy-combo-meals.test.ts
@@ -148,13 +148,14 @@ describe('FORK-run-uni-v2-like-liquidity-beefy-combo-meals', function run() {
     //   privateVaultTokenBalance,
     //   'Private LP token balance incorrect after adding liquidity',
     // );
+    const differenceWithExpected =
+      expectedPrivateVaultTokenBalance - privateVaultTokenBalance;
+    const tolerance = 10_000_000n;
     expect(
-      expectedPrivateVaultTokenBalance <= privateVaultTokenBalance &&
-        expectedPrivateVaultTokenBalance + 1000000000n >=
-          privateVaultTokenBalance,
+      -tolerance < differenceWithExpected && differenceWithExpected < tolerance,
     ).to.equal(
       true,
-      `Private Vault token balance incorrect after adding liquidity and depositing to vault, expected ${privateVaultTokenBalance} within 1000000000 of ${expectedPrivateVaultTokenBalance}`,
+      `Private Vault token balance incorrect after adding liquidity and depositing to vault, expected ${privateVaultTokenBalance} within ${tolerance} of ${expectedPrivateVaultTokenBalance}`,
     );
 
     // 2. Add External Balance expectations.


### PR DESCRIPTION
Previously, an integration test was checking whether vault token balance was **greater than** some expected value, **up to some margin** (1 billion).

Now, the vault token balance must be either **less than or greater than** the expected value, **within a tighter margin** (10 million).

In my experience this integration test stopped failing after this change.