### PR TITLE
chore: add unhandled edge case for missing liquidity 0x v2 trades

### DIFF
--- a/src/api/zero-x-v2/__tests__/zero-x-v2-quote.test.ts
+++ b/src/api/zero-x-v2/__tests__/zero-x-v2-quote.test.ts
@@ -1,6 +1,8 @@
 import { NetworkName } from '@railgun-community/shared-models';
 import { ZeroXV2Quote } from '../zero-x-v2-quote';
+import * as zeroXV2Api from '../zero-x-v2-fetch';
 import chai from 'chai';
+import sinon from 'sinon';
 import chaiAsPromised from 'chai-as-promised';
 import {
   RecipeERC20Amount,
@@ -8,6 +10,7 @@ import {
 } from '../../../models/export-models';
 import { ZeroXConfig } from '../../../models/zero-x-config';
 import { testConfig } from '../../../test/test-config.test';
+import { NoLiquidityError } from '../errors';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -41,32 +44,74 @@ const runV2QuoteTest = async (amount = '1000000000000000000') => {
 };
 
 describe('zero-x-v2-quote', () => {
+  let getZeroXV2DataStub: sinon.SinonStub;
   before(() => {});
+  
+  
+  beforeEach(() => {
+    ZeroXConfig.PROXY_API_DOMAIN = undefined;
+    ZeroXConfig.API_KEY = testConfig.zeroXApiKey;
 
-  it('Should fetch quotes from ZeroX proxy', async () => {
+    getZeroXV2DataStub = sinon.stub(zeroXV2Api, 'getZeroXV2Data');
+  });
+
+  afterEach(() => {
+    getZeroXV2DataStub.restore();
+  });
+
+
+  it('Should fetch quotes from ZeroXV2 proxy', async () => {
     ZeroXConfig.PROXY_API_DOMAIN = testConfig.zeroXProxyApiDomain;
     ZeroXConfig.API_KEY = undefined;
     await runV2QuoteTest();
   }).timeout(10000);
 
-  it('Should fetch quotes from ZeroX API Key', async () => {
-    ZeroXConfig.PROXY_API_DOMAIN = undefined;
-    ZeroXConfig.API_KEY = testConfig.zeroXApiKey;
+  it('Should fetch quotes from ZeroXV2 API Key', async () => {
     await runV2QuoteTest();
   }).timeout(10000);
 
-  it('Should fetch quotes from ZeroX API Key with large volume request', async () => {
-    ZeroXConfig.PROXY_API_DOMAIN = undefined;
-    ZeroXConfig.API_KEY = testConfig.zeroXApiKey;
-
+  it('Should fetch quotes from ZeroXV2 API Key with large volume request', async () => {
     await runV2QuoteTest('0x1000000000000000000000');
   }).timeout(10000);
 
-  it('Should fetch quotes from ZeroX API Key with large volume request and fail', async () => {
-    ZeroXConfig.PROXY_API_DOMAIN = undefined;
-    ZeroXConfig.API_KEY = testConfig.zeroXApiKey;
+  it('Should fetch quotes from ZeroXV2 API Key with large volume request and fail', async () => {
 
     await expect(runV2QuoteTest('0x10000000000000000000000000000000000000000'))
       .to.be.rejected;
   }).timeout(10000);
-});
+
+  it('Should error with no liquidity error when theres no liquidity for trade on ZeroXV2 API', async () => {
+  
+    const noLiquidityErrMessage = new NoLiquidityError().getCause();
+
+    const sellERC20Amount: RecipeERC20Amount = {
+      tokenAddress: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      decimals: 18n,
+      isBaseToken: false,
+      amount: BigInt('1000000000000000000'),
+    };
+
+    const buyERC20Info: RecipeERC20Info = {
+      tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+      decimals: 18n,
+      isBaseToken: false,
+    };
+
+    getZeroXV2DataStub.resolves({
+      liquidityAvailable: false,
+    });
+
+    try {
+      await ZeroXV2Quote.getSwapQuote({
+        networkName,
+        sellERC20Amount,
+        buyERC20Info,
+        slippageBasisPoints: 100,
+        isRailgun: true,
+      });
+    } catch(err) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(err.cause).to.contain(noLiquidityErrMessage);
+    }
+  });
+})

--- a/src/api/zero-x-v2/__tests__/zero-x-v2-quote.test.ts
+++ b/src/api/zero-x-v2/__tests__/zero-x-v2-quote.test.ts
@@ -47,18 +47,10 @@ describe('zero-x-v2-quote', () => {
   let getZeroXV2DataStub: sinon.SinonStub;
   before(() => {});
   
-  
   beforeEach(() => {
     ZeroXConfig.PROXY_API_DOMAIN = undefined;
     ZeroXConfig.API_KEY = testConfig.zeroXApiKey;
-
-    getZeroXV2DataStub = sinon.stub(zeroXV2Api, 'getZeroXV2Data');
   });
-
-  afterEach(() => {
-    getZeroXV2DataStub.restore();
-  });
-
 
   it('Should fetch quotes from ZeroXV2 proxy', async () => {
     ZeroXConfig.PROXY_API_DOMAIN = testConfig.zeroXProxyApiDomain;
@@ -82,6 +74,11 @@ describe('zero-x-v2-quote', () => {
 
   it('Should error with no liquidity error when theres no liquidity for trade on ZeroXV2 API', async () => {
   
+    const getZeroXV2DataStub = sinon.stub(zeroXV2Api, 'getZeroXV2Data').resolves({
+      liquidityAvailable: false,
+      // Add other necessary properties to match the expected response structure
+    });
+
     const noLiquidityErrMessage = new NoLiquidityError().getCause();
 
     const sellERC20Amount: RecipeERC20Amount = {
@@ -97,10 +94,6 @@ describe('zero-x-v2-quote', () => {
       isBaseToken: false,
     };
 
-    getZeroXV2DataStub.resolves({
-      liquidityAvailable: false,
-    });
-
     try {
       await ZeroXV2Quote.getSwapQuote({
         networkName,
@@ -112,6 +105,8 @@ describe('zero-x-v2-quote', () => {
     } catch(err) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(err.cause).to.contain(noLiquidityErrMessage);
+    } finally {
+      getZeroXV2DataStub.restore();
     }
   });
 })

--- a/src/api/zero-x-v2/errors.ts
+++ b/src/api/zero-x-v2/errors.ts
@@ -53,6 +53,15 @@ export class InvalidProxyContractChainError extends ZeroXAPIError {
   }
 }
 
+export class NoLiquidityError extends ZeroXAPIError {
+  constructor() {
+    super({
+      name: 'NoLiquidityError',
+      cause: 'No liquidity available for this trade',
+    });
+  }
+}
+
 export class SwapQuoteError extends ZeroXAPIError {
   constructor(cause: string) {
     super({

--- a/src/api/zero-x-v2/zero-x-v2-quote.ts
+++ b/src/api/zero-x-v2/zero-x-v2-quote.ts
@@ -121,6 +121,12 @@ export class ZeroXV2Quote {
         params,
       );
 
+      const { liquidityAvailable } = response;
+
+      if (!liquidityAvailable) {
+        throw new SwapQuoteError('No liquidity available for this trade');
+      }
+
       this.isValidQuote(
         networkName,
         response.transaction.to,

--- a/src/api/zero-x-v2/zero-x-v2-quote.ts
+++ b/src/api/zero-x-v2/zero-x-v2-quote.ts
@@ -13,7 +13,7 @@ import type {
 import { getZeroXV2Data, ZeroXV2ApiEndpoint } from './zero-x-v2-fetch';
 import { minBalanceAfterSlippage } from '../../utils/number';
 import { formatUnits, parseUnits, type ContractTransaction } from 'ethers';
-import { InvalidExchangeContractError, SwapQuoteError, InvalidProxyContractChainError, QuoteParamsError } from './errors';
+import { InvalidExchangeContractError, SwapQuoteError, InvalidProxyContractChainError, QuoteParamsError, NoLiquidityError } from './errors';
 import { ZERO_X_EXCHANGE_ALLOWANCE_HOLDER_ADDRESS, ZERO_X_PROXY_BASE_TOKEN_ADDRESS } from '../../models/constants';
 
 export class ZeroXV2Quote {
@@ -124,7 +124,7 @@ export class ZeroXV2Quote {
       const { liquidityAvailable } = response;
 
       if (!liquidityAvailable) {
-        throw new SwapQuoteError('No liquidity available for this trade');
+        throw new NoLiquidityError();
       }
 
       this.isValidQuote(

--- a/src/recipes/vault/beefy/__tests__/FORK-run-beefy-vault-recipes.test.ts
+++ b/src/recipes/vault/beefy/__tests__/FORK-run-beefy-vault-recipes.test.ts
@@ -41,7 +41,7 @@ const vaultERC20Address = testConfig.contractsEthereum.mooConvexTriCryptoUSDC;
 const oneWithDecimals = 10n ** 18n;
 
 describe('FORK-run-beefy-vault-recipes', function run() {
-  this.timeout(60000);
+  this.timeout(80000);
 
   before(async function run() {
     setRailgunFees(


### PR DESCRIPTION
* Adds new error for insufficient liquidity for trades with really low input 
* Adds unit test for handling those cases

misc: 

* Renames ZeroXV2 Tests description from `zero x` to `zero x v2`
* Adds beforeEach hook to avoid repetition for test setup 