### PR TITLE
Fix: calculate minDecimalFixedInt

### DIFF
--- a/src/api/zero-x-v2/zero-x-v2-quote.ts
+++ b/src/api/zero-x-v2/zero-x-v2-quote.ts
@@ -178,12 +178,13 @@ export class ZeroXV2Quote {
         formatUnits(sellERC20Amount.amount, sellERC20Amount.decimals),
       );
 
+      const minDecimalFixedInt = parseInt(sellERC20Amount.decimals.toString());
       const price = parseUnits(
-        (priceBuyAmount / priceSellAmount).toFixed(8),
+        (priceBuyAmount / priceSellAmount).toFixed(minDecimalFixedInt),
         sellERC20Amount.decimals,
       );
       const guaranteedPrice = parseUnits(
-        (minPriceBuyAmount / priceSellAmount).toFixed(8),
+        (minPriceBuyAmount / priceSellAmount).toFixed(minDecimalFixedInt),
         sellERC20Amount.decimals,
       );
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/e7acb882-15cb-4602-a610-2c63aaea797e)


Previous implementation was making `parseUnits` from ethers throw whenever there was an incorrect amount of decimals 

ie: with 
```
const minPriceBuyAmount = 0.000258395254261705;
const priceSellAmount = 0.0001;
```

and decimals being as `6` (USDT), parseUnits would throw the following => 

```
  code: 'NUMERIC_FAULT',
  operation: 'fromString',
  fault: 'underflow',
  value: '2.5839525426170495',
  shortMessage: 'too many decimals for format'
```

causing the receipt output to fail. 

This fixes that issue by setting a min decimal bounded to the `sellERC20Amount` we're using to calculate prices with 