### PR TITLE
Fix: support active wallet address for 0x V2 swaps

### DIFF
--- a/src/api/zero-x-v2/zero-x-v2-quote.ts
+++ b/src/api/zero-x-v2/zero-x-v2-quote.ts
@@ -53,6 +53,7 @@ export class ZeroXV2Quote {
     sellERC20Amount: RecipeERC20Amount,
     buyERC20Info: RecipeERC20Info,
     slippageBasisPoints: number,
+    activeWalletAddress: Optional<string>,
   ): QuoteParamsV2 => {
     if (sellERC20Amount.amount === 0n) {
       throw new QuoteParamsError('Swap sell amount is 0.');
@@ -65,13 +66,14 @@ export class ZeroXV2Quote {
     if (sellTokenAddress === buyTokenAddress) {
       throw new QuoteParamsError('Swap sell and buy tokens are the same');
     }
+
     const params: QuoteParamsV2 = {
       chainId: chain.id.toString(),
       sellToken: sellTokenAddress,
       buyToken: buyTokenAddress,
       sellAmount: sellERC20Amount.amount.toString(),
-      taker: relayAdaptContract,
-      txOrigin: relayAdaptContract,
+      taker: activeWalletAddress ?? relayAdaptContract,
+      txOrigin: activeWalletAddress ?? relayAdaptContract,
       slippageBps: slippageBasisPoints,
       excludedSources: "0x_RFQ,Uniswap_V3"
     };
@@ -116,12 +118,14 @@ export class ZeroXV2Quote {
     buyERC20Info,
     slippageBasisPoints,
     isRailgun,
+    activeWalletAddress,
   }: SwapQuoteParamsV2): Promise<SwapQuoteDataV2> => {
     const params = ZeroXV2Quote.getQuoteParams(
       networkName,
       sellERC20Amount,
       buyERC20Info,
       slippageBasisPoints,
+      isRailgun ? undefined : activeWalletAddress
     );
 
     try {

--- a/src/models/export-models.ts
+++ b/src/models/export-models.ts
@@ -125,6 +125,7 @@ export type SwapQuoteParamsV2 = {
   buyERC20Info: RecipeERC20Info;
   slippageBasisPoints: number;
   isRailgun: boolean;
+  activeWalletAddress?: string;
 };
 
 export type GetSwapQuote = (


### PR DESCRIPTION
Previous public swaps where failing because of the `relayAdaptContract` being set for both public and private swaps. This is fundamentally wrong since public swaps should be received and triggered by the active public wallet. 

Consequence for this was all swaps being done through public were mistakenly sending the swap tokens to the `relayAdaptContract` address. 

Since we know beforehand what type of swap is (thanks to `isRailgun`), adding `activeWalletAddress` for the scenario where swaps are public fixes this.