### PR TITLE
fix: make unit tests deterministic and skip API-dependent tests without credentials

### DIFF
--- a/src/api/zero-x-v2/__tests__/zero-x-v2-quote.test.ts
+++ b/src/api/zero-x-v2/__tests__/zero-x-v2-quote.test.ts
@@ -43,31 +43,45 @@ const runV2QuoteTest = async (amount = '1000000000000000000') => {
   expect(quote).to.haveOwnProperty('sellTokenValue');
 };
 
+const hasZeroXApiKey = () => testConfig.zeroXApiKey !== '' && testConfig.zeroXApiKey !== 'REPLACE_ME';
+const hasZeroXProxy = () => testConfig.zeroXProxyApiDomain !== '' && testConfig.zeroXProxyApiDomain !== 'REPLACE_ME';
+
 describe('zero-x-v2-quote', () => {
   let getZeroXV2DataStub: sinon.SinonStub;
   before(() => {});
-  
+
   beforeEach(() => {
     ZeroXConfig.PROXY_API_DOMAIN = undefined;
     ZeroXConfig.API_KEY = testConfig.zeroXApiKey;
   });
 
-  it('Should fetch quotes from ZeroXV2 proxy', async () => {
+  it('Should fetch quotes from ZeroXV2 proxy', async function () {
+    if (!hasZeroXProxy()) {
+      this.skip();
+    }
     ZeroXConfig.PROXY_API_DOMAIN = testConfig.zeroXProxyApiDomain;
     ZeroXConfig.API_KEY = undefined;
     await runV2QuoteTest();
   }).timeout(10000);
 
-  it('Should fetch quotes from ZeroXV2 API Key', async () => {
+  it('Should fetch quotes from ZeroXV2 API Key', async function () {
+    if (!hasZeroXApiKey()) {
+      this.skip();
+    }
     await runV2QuoteTest();
   }).timeout(10000);
 
-  it('Should fetch quotes from ZeroXV2 API Key with large volume request', async () => {
+  it('Should fetch quotes from ZeroXV2 API Key with large volume request', async function () {
+    if (!hasZeroXApiKey()) {
+      this.skip();
+    }
     await runV2QuoteTest('0x1000000000000000000000');
   }).timeout(10000);
 
-  it('Should fetch quotes from ZeroXV2 API Key with large volume request and fail', async () => {
-
+  it('Should fetch quotes from ZeroXV2 API Key with large volume request and fail', async function () {
+    if (!hasZeroXApiKey()) {
+      this.skip();
+    }
     await expect(runV2QuoteTest('0x10000000000000000000000000000000000000000'))
       .to.be.rejected;
   }).timeout(10000);

--- a/src/recipes/liquidity/uni-v2-like/__tests__/uniswap-v2-add-liquidity-recipe.test.ts
+++ b/src/recipes/liquidity/uni-v2-like/__tests__/uniswap-v2-add-liquidity-recipe.test.ts
@@ -9,6 +9,7 @@ import {
   MOCK_UNSHIELD_FEE_BASIS_POINTS,
 } from '../../../../test/mocks.test';
 import { UniV2LikePairContract } from '../../../../contract/liquidity/uni-v2-like-pair-contract';
+import { UniV2LikeFactoryContract } from '../../../../contract/liquidity/uni-v2-like-factory-contract';
 import {
   RecipeERC20Info,
   RecipeInput,
@@ -16,6 +17,7 @@ import {
 } from '../../../../models/export-models';
 import { UniV2LikeAddLiquidityRecipe } from '../uni-v2-like-add-liquidity-recipe';
 import { JsonRpcProvider } from 'ethers';
+import { ZERO_ADDRESS } from '../../../../models/constants';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -45,6 +47,8 @@ const LP_TOKEN: RecipeERC20Info = {
 let dateStub: SinonStub;
 let uniswapV2PairGetReserves: SinonStub;
 let uniswapV2PairTotalSupply: SinonStub;
+let uniswapV2PairKLast: SinonStub;
+let uniswapV2FactoryFeeTo: SinonStub;
 
 const provider = new JsonRpcProvider('https://eth.llamarpc.com');
 
@@ -68,12 +72,22 @@ describe('uniswap-v2-add-liquidity-recipe', () => {
       UniV2LikePairContract.prototype,
       'totalSupply',
     ).resolves(oneInDecimals18 * 2_000_000n);
+    uniswapV2PairKLast = Sinon.stub(
+      UniV2LikePairContract.prototype,
+      'kLast',
+    ).resolves(0n);
+    uniswapV2FactoryFeeTo = Sinon.stub(
+      UniV2LikeFactoryContract.prototype,
+      'feeTo',
+    ).resolves(ZERO_ADDRESS);
   });
 
   after(() => {
     dateStub.restore();
     uniswapV2PairGetReserves.restore();
     uniswapV2PairTotalSupply.restore();
+    uniswapV2PairKLast.restore();
+    uniswapV2FactoryFeeTo.restore();
   });
 
   it('Should create uniswap-v2-add-liquidity-recipe', async () => {

--- a/src/recipes/liquidity/uni-v2-like/__tests__/uniswap-v2-remove-liquidity-recipe.test.ts
+++ b/src/recipes/liquidity/uni-v2-like/__tests__/uniswap-v2-remove-liquidity-recipe.test.ts
@@ -9,6 +9,7 @@ import {
   MOCK_UNSHIELD_FEE_BASIS_POINTS,
 } from '../../../../test/mocks.test';
 import { UniV2LikePairContract } from '../../../../contract/liquidity/uni-v2-like-pair-contract';
+import { UniV2LikeFactoryContract } from '../../../../contract/liquidity/uni-v2-like-factory-contract';
 import {
   RecipeERC20Info,
   RecipeInput,
@@ -16,6 +17,7 @@ import {
 } from '../../../../models/export-models';
 import { UniV2LikeRemoveLiquidityRecipe } from '../uni-v2-like-remove-liquidity-recipe';
 import { JsonRpcProvider } from 'ethers';
+import { ZERO_ADDRESS } from '../../../../models/constants';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -45,6 +47,8 @@ const LP_TOKEN: RecipeERC20Info = {
 let dateStub: SinonStub;
 let uniswapV2PairGetReserves: SinonStub;
 let uniswapV2PairTotalSupply: SinonStub;
+let uniswapV2PairKLast: SinonStub;
+let uniswapV2FactoryFeeTo: SinonStub;
 
 const provider = new JsonRpcProvider('https://eth.llamarpc.com');
 
@@ -68,12 +72,22 @@ describe('uniswap-v2-remove-liquidity-recipe', () => {
       UniV2LikePairContract.prototype,
       'totalSupply',
     ).resolves(oneInDecimals18 * 2_000_000n);
+    uniswapV2PairKLast = Sinon.stub(
+      UniV2LikePairContract.prototype,
+      'kLast',
+    ).resolves(0n);
+    uniswapV2FactoryFeeTo = Sinon.stub(
+      UniV2LikeFactoryContract.prototype,
+      'feeTo',
+    ).resolves(ZERO_ADDRESS);
   });
 
   after(() => {
     dateStub.restore();
     uniswapV2PairGetReserves.restore();
     uniswapV2PairTotalSupply.restore();
+    uniswapV2PairKLast.restore();
+    uniswapV2FactoryFeeTo.restore();
   });
 
   it('Should create uniswap-v2-remove-liquidity-recipe', async () => {


### PR DESCRIPTION
## Summary
  - Stub `kLast` and `feeTo` in liquidity recipe tests to eliminate live RPC
   dependency — these were the only unstubbed contract methods, causing test
   failures when on-chain state changed
  - Skip zero-x-v2-quote tests when `ZERO_X_API_KEY` / `PROXY_API_DOMAIN`
  aren't configured (matches v1 test pattern)

  ## What changed
  - No production code changes
  - No new mock data or math — just completed existing stub pattern with
  `0n`/`ZERO_ADDRESS` (no LP protocol fee)
  - Added `this.skip()` guards for API-dependent tests

  ## Test plan
  - `yarn test` → 81 passing, 21 pending, 0 failing